### PR TITLE
msm8916: Update audio property configurations to M

### DIFF
--- a/product/qcom-audio.mk
+++ b/product/qcom-audio.mk
@@ -12,9 +12,11 @@ PRODUCT_COPY_FILES += \
 # Properties
 PRODUCT_PROPERTY_OVERRIDES += \
     av.streaming.offload.enable=true \
+    audio.deep_buffer.media=true \
     audio.offload.buffer.size.kb=64 \
     audio.offload.gapless.enabled=true \
     audio.offload.min.duration.secs=30 \
     audio.offload.pcm.16bit.enable=false \
     audio.offload.pcm.24bit.enable=true \
+    audio.offload.video=true \
     use.voice.path.for.pcm.voip=true


### PR DESCRIPTION
- audio.deep_buffer.media
  On L, this was enabled by default, on M we have to set it
  specifically to true.
- av.offload.enable/audio.offload.video
  av.offload.enable on L is now called audio.offload.video on M.
  This prop was previously removed as it was thought to be obsolete.

Change-Id: I2500703cbaaf59ab97858356a255619b0fa07bff
