### PR TITLE
msm8916: init: Set rps mask value to 2 for 8916

### DIFF
--- a/rootdir/etc/init.qcom.power_msm8916.rc
+++ b/rootdir/etc/init.qcom.power_msm8916.rc
@@ -35,6 +35,9 @@ on enable-low-power
     # Enable low power modes
     write /sys/module/lpm_levels/parameters/sleep_disabled 0
 
+    # Set RPS mask
+    write /sys/class/net/rmnet0/queues/rx-0/rps_cpus 2
+
     # Update foreground and background cpusets
     write /dev/cpuset/foreground/cpus 0-3
     write /dev/cpuset/foreground/boost/cpus 0-3


### PR DESCRIPTION
Enable rps with the mask value of 2 during the time of initialization.

Change-Id: I0f932f6e5e8372d638be2c90778bdd0bae159e76
CRs-fixed: 902473
