### PR TITLE
msm8916: Add support for top-app cpuset

### DIFF
--- a/rootdir/etc/init.qcom.power_msm8916.rc
+++ b/rootdir/etc/init.qcom.power_msm8916.rc
@@ -39,10 +39,12 @@ on enable-low-power
     write /sys/class/net/rmnet0/queues/rx-0/rps_cpus 2
 
     # Update foreground and background cpusets
-    write /dev/cpuset/foreground/cpus 0-3
+    # Reserve CPU 3 for the top app
+    write /dev/cpuset/foreground/cpus 0-2
     write /dev/cpuset/foreground/boost/cpus 0-3
     write /dev/cpuset/background/cpus 0
     write /dev/cpuset/system-background/cpus 0-1
+    write /dev/cpuset/top-app/cpus 0-3
 
     rm /data/system/perfd/default_values
     start perfd

--- a/rootdir/etc/init.qcom.power_msm8939.rc
+++ b/rootdir/etc/init.qcom.power_msm8939.rc
@@ -69,10 +69,12 @@ on enable-low-power
     write /sys/module/lpm_levels/parameters/sleep_disabled 0
 
     # Update foreground and background cpusets
-    write /dev/cpuset/foreground/cpus 0-7
+    # Reserve CPU 7 for the top app
+    write /dev/cpuset/foreground/cpus 0-6
     write /dev/cpuset/foreground/boost/cpus 0-3
     write /dev/cpuset/background/cpus 4
-    write /dev/cpuset/system-background/cpus 4-7
+    write /dev/cpuset/system-background/cpus 4-6
+    write /dev/cpuset/top-app/cpus 0-7
 
     # Per-process reclaim
     write /sys/module/process_reclaim/parameters/enable_process_reclaim 1


### PR DESCRIPTION
Reserve one little core for the top app.

For msm8939: Reserve core 7 for the top app
For msm8916: Reserve core 3 for the top app

Change-Id: I8a8540313572a4d109c06d0de11c1dd6a7b50f5a