### PR TITLE
msm8916: Remove no-op TARGET_KERNEL_ARCH flag

### DIFF
--- a/board/kernel.mk
+++ b/board/kernel.mk
@@ -11,8 +11,5 @@ ENABLE_CPUSETS := true
 
 TARGET_KERNEL_SOURCE := kernel/cyanogen/msm8916
 ifneq ($(FORCE_32_BIT),true)
-TARGET_KERNEL_ARCH := arm64
 TARGET_USES_UNCOMPRESSED_KERNEL := true
-else
-TARGET_KERNEL_ARCH := arm
 endif


### PR DESCRIPTION
TARGET_KERNEL_ARCH is a no-op unless it is different from TARGET_ARCH.

Change-Id: If36d5adc3296b76d5efb21da0e196f0b005ae784