### PR TITLE
Enable delay service restart

### DIFF
--- a/product/perf.mk
+++ b/product/perf.mk
@@ -5,5 +5,6 @@ PRODUCT_PROPERTY_OVERRIDES += \
 endif
 
 PRODUCT_PROPERTY_OVERRIDES += \
+    ro.am.reschedule_service=true \
     ro.config.max_starting_bg=8 \
     ro.sys.fw.use_trim_settings=true


### PR DESCRIPTION
This patch turns on system property "ro.am.reschedule_service".
This helps to postpone services restarts during app launch.
Only the services that are not relevant to current app launch are
considered for postpone.

Change-Id: I908be6dd7f7991b830a0440276fb9e2a0c0314c3